### PR TITLE
Fix browser proxy agent import

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,7 @@
     <script type="importmap">
         {
           "imports": {
-            "@google/genai": "https://esm.run/@google/genai",
-            "node-fetch": "https://esm.run/node-fetch",
-            "https-proxy-agent": "https://cdn.jsdelivr.net/npm/https-proxy-agent/dist/index.min.js"
+            "@google/genai": "https://esm.run/@google/genai"
           }
         }
     </script>


### PR DESCRIPTION
## Summary
- don't load node-fetch or https-proxy-agent in browser
- warn when proxy URL is provided in the browser
- use dynamic imports in gemini wrapper
- simplify import map in index.html

## Testing
- `npx tsc`
- `node test-gemini.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68857cb63c3083308eb21bdf06b714b6