### PR TITLE
Refine spinners and markdown rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
                             <div class="stepper-line"></div>
                             <div class="stepper-content">
                                 <div class="stepper-title">文档分析</div>
-                                <div class="stepper-status">待处理</div>
+                                <div class="stepper-status"><span class="spinner-small spinner-waiting"></span></div>
                                 <div class="stepper-time">等待开始...</div>
                             </div>
                             <button class="stepper-details-btn" onclick="showStepDetails('step-document-analysis')">
@@ -112,7 +112,7 @@
                             <div class="stepper-line"></div>
                             <div class="stepper-content">
                                 <div class="stepper-title">内容提取</div>
-                                <div class="stepper-status">待处理</div>
+                                <div class="stepper-status"><span class="spinner-small spinner-waiting"></span></div>
                                 <div class="stepper-time">等待开始...</div>
                             </div>
                             <button class="stepper-details-btn" onclick="showStepDetails('step-chunk-extraction')">
@@ -125,7 +125,7 @@
                             <div class="stepper-line"></div>
                             <div class="stepper-content">
                                 <div class="stepper-title">报告生成</div>
-                                <div class="stepper-status">待处理</div>
+                                <div class="stepper-status"><span class="spinner-small spinner-waiting"></span></div>
                                 <div class="stepper-time">等待开始...</div>
                             </div>
                             <button class="stepper-details-btn" onclick="showStepDetails('step-report-generation')">
@@ -138,7 +138,7 @@
                             <div class="stepper-line"></div>
                             <div class="stepper-content">
                                 <div class="stepper-title">内容增强</div>
-                                <div class="stepper-status">待处理</div>
+                                <div class="stepper-status"><span class="spinner-small spinner-waiting"></span></div>
                                 <div class="stepper-time">等待开始...</div>
                             </div>
                             <button class="stepper-details-btn" onclick="showStepDetails('step-enhancement')">
@@ -150,7 +150,7 @@
                             <div class="stepper-circle">5</div>
                             <div class="stepper-content">
                                 <div class="stepper-title">最终处理</div>
-                                <div class="stepper-status">待处理</div>
+                                <div class="stepper-status"><span class="spinner-small spinner-waiting"></span></div>
                                 <div class="stepper-time">等待开始...</div>
                             </div>
                             <button class="stepper-details-btn" onclick="showStepDetails('step-finalization')">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@google/genai": "^1.11.0",
         "dotenv": "^17.2.1",
         "https-proxy-agent": "^7.0.6",
+        "marked": "^11.2.0",
         "mime": "^4.0.7",
         "node-fetch": "^2.7.0",
         "socks-proxy-agent": "^8.0.5"
@@ -521,6 +522,18 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@google/genai": "^1.11.0",
     "dotenv": "^17.2.1",
     "https-proxy-agent": "^7.0.6",
+    "marked": "^11.2.0",
     "mime": "^4.0.7",
     "node-fetch": "^2.7.0",
     "socks-proxy-agent": "^8.0.5"

--- a/src/agents/final-formatter.js
+++ b/src/agents/final-formatter.js
@@ -1,5 +1,6 @@
 // Final formatting agent to ensure enhanced reports are properly formatted and displayed
 import { generateWithRetry, convertContentParts } from '../utils/gemini-wrapper.js';
+import { marked } from 'https://cdn.jsdelivr.net/npm/marked@11.2.0/+esm';
 
 // Load prompts from centralized JSON files
 let formatterPrompts = null;
@@ -209,33 +210,10 @@ export function formatForDisplay(report) {
         return '<div class="error">无效的报告内容</div>';
     }
 
-    // Convert markdown-style formatting to HTML
-    let htmlReport = report
-        // Headers
-        .replace(/^### (.*$)/gm, '<h3>$1</h3>')
-        .replace(/^#### (.*$)/gm, '<h4>$1</h4>')
-        .replace(/^##### (.*$)/gm, '<h5>$1</h5>')
-        
-        // Bold text
-        .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-        
-        // Line breaks
-        .replace(/\n\n/g, '</p><p>')
-        .replace(/\n/g, '<br>')
-        
-        // Wrap in paragraphs
-        .replace(/^(.)/gm, '<p>$1')
-        .replace(/(.*)<\/p>/gm, '$1</p>')
-        
-        // Clean up empty paragraphs
-        .replace(/<p><\/p>/g, '')
-        .replace(/<p><br>/g, '<p>')
-        
-        // Handle lists
-        .replace(/^[•·-] (.*)$/gm, '<li>$1</li>')
-        .replace(/(<li>.*<\/li>)/s, '<ul>$1</ul>')
-        
-        // Numbers and percentages styling
+    // Use marked library for Markdown to HTML conversion
+    let htmlReport = marked.parse(report);
+    // Highlight numbers and percentages
+    htmlReport = htmlReport
         .replace(/(\d+(?:\.\d+)?%)/g, '<span class="number">$1</span>')
         .replace(/(\d+(?:,\d{3})*(?:\.\d+)?)/g, '<span class="number">$1</span>');
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -187,8 +187,6 @@ button:disabled {
     white-space: pre-wrap;
     font-family: 'Waldenburg', 'Microsoft YaHei', sans-serif;
     line-height: 1.8;
-    max-height: 600px;
-    overflow-y: auto;
     padding: 20px;
     border: 1px solid #444;
     border-radius: 8px;
@@ -1274,21 +1272,25 @@ small {
 }
 
 .task-status-badge {
-    padding: 2px 8px;
-    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-weight: 600;
-    text-transform: uppercase;
     font-size: 0.75em;
+    text-transform: uppercase;
 }
 
-.task-status-badge.pending { background: #ffc107; color: #000; }
-.task-status-badge.processing { background: #17a2b8; color: #fff; }
-.task-status-badge.completed { background: #28a745; color: #fff; }
+.task-status-badge.pending,
+.task-status-badge.processing,
+.task-status-badge.completed {
+    background: none;
+    color: inherit;
+}
 
 .task-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 8px;
     margin-bottom: 15px;
     padding-bottom: 10px;
     border-bottom: 1px solid #444;
@@ -1301,33 +1303,25 @@ small {
 }
 
 .task-status {
-    padding: 4px 12px;
-    border-radius: 20px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     font-size: 0.85em;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
 
-.task-status.pending {
-    background: #ffc107;
-    color: #000;
+.task-status.pending,
+.task-status.processing,
+.task-status.completed,
+.task-status.error {
+    background: none;
+    color: inherit;
 }
 
 .task-status.processing {
-    background: #17a2b8;
-    color: #fff;
     animation: pulse 2s infinite;
-}
-
-.task-status.completed {
-    background: #28a745;
-    color: #fff;
-}
-
-.task-status.error {
-    background: #dc3545;
-    color: #fff;
 }
 
 @keyframes pulse {
@@ -1982,36 +1976,9 @@ small {
 .task-progress {
     display: none;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
 }
 
-.progress-dots {
-    display: flex;
-    gap: 4px;
-}
-
-.progress-dots .dot {
-    width: 6px;
-    height: 6px;
-    background: #17a2b8;
-    border-radius: 50%;
-    animation: progress-dot-bounce 1.4s ease-in-out infinite both;
-}
-
-.progress-dots .dot:nth-child(1) { animation-delay: -0.32s; }
-.progress-dots .dot:nth-child(2) { animation-delay: -0.16s; }
-.progress-dots .dot:nth-child(3) { animation-delay: 0s; }
-
-@keyframes progress-dot-bounce {
-    0%, 80%, 100% {
-        transform: scale(0.8);
-        opacity: 0.5;
-    }
-    40% {
-        transform: scale(1.2);
-        opacity: 1;
-    }
-}
 
 /* Enhanced Stats Display */
 .stats-row {


### PR DESCRIPTION
## Summary
- streamline task status styles with no background
- show spinner icons directly beside each subtask title and progress text
- parse all dynamic content with `marked`
- keep stepper spinners while removing text truncation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b24d4bdd48330a738a953009cf0ac