### PR TITLE
Fix bare specifier import error for docx

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
     <script type="importmap">
         {
           "imports": {
-            "@google/genai": "https://esm.run/@google/genai"
+            "@google/genai": "https://esm.run/@google/genai",
+            "docx": "https://esm.run/docx@9.5.1"
           }
         }
     </script>


### PR DESCRIPTION
The Word export functionality was failing with:
"TypeError: The specifier 'docx' was a bare specifier, but was not remapped to anything"

This occurred because src/utils/word-export.js imports docx as a bare specifier, but the browser's import map only included @google/genai.

Added docx@9.5.1 to the import map pointing to esm.run CDN to enable proper module resolution in the browser.